### PR TITLE
Change implementation to use for loops

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+node_modules
+coverage

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 {
-  "printWidth": 90,
+  "printWidth": 80,
   "semi": false,
   "trailingComma": "all",
   "singleQuote": true,

--- a/benchmarks/big-array.js
+++ b/benchmarks/big-array.js
@@ -1,0 +1,64 @@
+/* eslint-disable no-console,camelcase,no-plusplus,no-use-before-define */
+const smoothMap = require('./map-implementation')
+const smoothFor = require('../lib')
+const sample = require('../test/fixture')
+
+const base = 1000 * sample.length
+
+const a = base * 10
+const b = base * 100
+// const c = base * 1000 // 38 million items
+
+console.log('Running benchmarks...')
+console.log()
+
+large_array_benchmark(a, 5)
+large_array_benchmark(a, 5, (v) => ({ value: v }), (v) => v.value)
+large_array_benchmark(a, 20)
+large_array_benchmark(b, 5)
+
+// large_array_benchmark(c, 2)
+// large_array_benchmark(c, 5)
+// large_array_benchmark(c, 20)
+
+function large_array_benchmark(times, smooth_factor, map, getter) {
+  if (map && !getter) {
+    throw new Error('Please provide both mapper and getter!')
+  }
+
+  console.time('Creating array took')
+  const big_array = Array(times)
+
+  for (let i = 0; i < times; i++) {
+    big_array[i] = map
+      ? map(sample[i % sample.length])
+      : sample[i % sample.length]
+  }
+  console.timeEnd('Creating array took')
+
+  console.log()
+  console.log(`Sample: array of ${typeof big_array[0]}s`)
+  console.log(`Length: ${big_array.length}`)
+  console.log(`Smooth: ${smooth_factor}`)
+  console.log()
+
+  console.time('for')
+  if (getter) {
+    smoothFor(big_array, smooth_factor, getter)
+  } else {
+    smoothFor(big_array, smooth_factor)
+  }
+  console.timeEnd('for')
+
+  console.time('map')
+  if (getter) {
+    smoothMap(big_array, smooth_factor, getter)
+  } else {
+    smoothMap(big_array, smooth_factor)
+  }
+  console.timeEnd('map')
+
+  console.log()
+  console.log('--------------------')
+  console.log()
+}

--- a/benchmarks/map-implementation.js
+++ b/benchmarks/map-implementation.js
@@ -1,0 +1,40 @@
+const dotProp = require('dot-prop')
+
+function getSample(arr, index, offset) {
+  const leftOffeset = index - offset
+  const from = leftOffeset >= 0 ? leftOffeset : 0
+  const to = index + offset + 1
+  return arr.slice(from, to)
+}
+
+function buildAccessors(accessor, accessorName) {
+  if (!accessor) {
+    return accessorName === 'get' ? (item) => item : undefined
+  }
+  if (typeof accessor === 'function') {
+    return accessor
+  }
+  if (typeof accessor === 'string') {
+    return (item, itemSmoothed) =>
+      dotProp[accessorName](item, accessor, itemSmoothed)
+  }
+  const accessorFullName = accessorName === 'set' ? 'setter' : 'getter'
+  throw new Error(`Error ${accessorFullName} must be a function or a string`)
+}
+
+function smooth(arr, smoothOffset, getter, setter) {
+  const get = buildAccessors(getter, 'get')
+  const set = buildAccessors(setter, 'set')
+
+  return arr.map((item, index, arr) => {
+    const sample = getSample(arr, index, smoothOffset).map(get)
+    const smoothed = sample.reduce((a, b) => a + b, 0) / sample.length
+    if (!set) {
+      return smoothed
+    }
+    set(item, smoothed)
+    return item
+  })
+}
+
+module.exports = smooth

--- a/benchmarks/ops-per-second.js
+++ b/benchmarks/ops-per-second.js
@@ -1,0 +1,50 @@
+/* eslint-disable camelcase,no-use-before-define,no-console */
+/* eslint-disable import/no-extraneous-dependencies */
+const Benchmark = require('benchmark')
+
+const smoothMap = require('./map-implementation')
+const smoothFor = require('../lib')
+const sample = require('../test/fixture')
+
+console.log('Running benchmarks...')
+console.log()
+
+benchmarkCase(sample, 2)
+benchmarkCase(sample, 10)
+
+const s = sample.map((v) => ({ value: v }))
+
+benchmarkCase(s, 2, (v) => v.value)
+
+// -------------------------------------
+
+function benchmarkCase(arr, smooth, getter) {
+  const suite = new Benchmark.Suite()
+  const events = []
+
+  suite
+    .add('Smooth (map)', () => {
+      smoothMap(arr, smooth, getter)
+    })
+    .add('Smooth (for)', () => {
+      smoothFor(arr, smooth, getter)
+    })
+    .on('cycle', (event) => {
+      events.push(String(event.target))
+    })
+    .on('complete', () => {
+      console.log('Ran benchmarks with:')
+      console.log()
+      console.log(`Smooth: ${smooth}`)
+      console.log(`Sample: array of ${typeof arr[0]}s`)
+      console.log(`Length: ${arr.length}`)
+      console.log()
+      events.forEach((e) => console.log(e))
+      console.log()
+      console.log(`Fastest is ${suite.filter('fastest').map('name')}`)
+      console.log()
+      console.log('------------------------------------------------')
+      console.log()
+    })
+    .run({ async: true })
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,12 +1,5 @@
 const dotProp = require('dot-prop')
 
-function getSample(arr, index, offset) {
-  const leftOffeset = index - offset
-  const from = leftOffeset >= 0 ? leftOffeset : 0
-  const to = index + offset + 1
-  return arr.slice(from, to)
-}
-
 function buildAccessors(accessor, accessorName) {
   if (!accessor) {
     return accessorName === 'get' ? (item) => item : undefined
@@ -15,7 +8,8 @@ function buildAccessors(accessor, accessorName) {
     return accessor
   }
   if (typeof accessor === 'string') {
-    return (item, itemSmoothed) => dotProp[accessorName](item, accessor, itemSmoothed)
+    return (item, itemSmoothed) =>
+      dotProp[accessorName](item, accessor, itemSmoothed)
   }
   const accessorFullName = accessorName === 'set' ? 'setter' : 'getter'
   throw new Error(`Error ${accessorFullName} must be a function or a string`)
@@ -25,15 +19,28 @@ function smooth(arr, smoothOffset, getter, setter) {
   const get = buildAccessors(getter, 'get')
   const set = buildAccessors(setter, 'set')
 
-  return arr.map((item, index, arr) => {
-    const sample = getSample(arr, index, smoothOffset).map(get)
-    const smoothed = sample.reduce((a, b) => a + b, 0) / sample.length
-    if (!set) {
-      return smoothed
+  const result = []
+
+  for (let i = 0; i < arr.length; i++) {
+    const leftOffeset = i - smoothOffset
+    const from = leftOffeset >= 0 ? leftOffeset : 0
+    const to = i + smoothOffset + 1
+
+    let count = 0
+    let sum = 0
+    for (let j = from; j < to && j < arr.length; j++) {
+      sum += get(arr[j])
+      count++
     }
-    set(item, smoothed)
-    return item
-  })
+
+    if (set) {
+      set(arr[i], sum / count)
+    } else {
+      result[i] = sum / count
+    }
+  }
+
+  return set ? arr : result
 }
 
 module.exports = smooth

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "homepage": "https://github.com/ndelvalle/array-smooth#readme",
   "devDependencies": {
+    "benchmark": "^2.1.4",
     "eslint": "^4.19.1",
     "eslint-config-airbnb-base": "^12.1.0",
     "eslint-config-prettier": "^2.9.0",
@@ -36,6 +37,7 @@
     "eslint-plugin-prettier": "^2.6.0",
     "husky": "^0.14.3",
     "jest": "^23.0.1",
+    "microtime": "^2.1.8",
     "prettier": "^1.13.0",
     "pretty-quick": "^1.6.0"
   },


### PR DESCRIPTION
Changed implementation to use `for` loops instead of map/reduce. Changes improve performance a lot.

Also added some benchmarks.

Some ops/second benchmarks with the small sample array (the one used in tests):

```
smooth: 2
sample: array of numbers
length: 38

Smooth (map) x 69,313 ops/sec ±0.58% (89 runs sampled)
Smooth (for) x 560,283 ops/sec ±0.60% (86 runs sampled)

Fastest is Smooth (for)

------------------------------------------------

smooth: 10
sample: array of numbers
length: 38

Smooth (map) x 30,805 ops/sec ±0.56% (95 runs sampled)
Smooth (for) x 170,761 ops/sec ±0.70% (90 runs sampled)

Fastest is Smooth (for)

------------------------------------------------

smooth: 2
sample: array of objects
length: 38

Smooth (map) x 59,144 ops/sec ±0.47% (92 runs sampled)
Smooth (for) x 551,857 ops/sec ±0.92% (94 runs sampled)

Fastest is Smooth (for)
```

Some cases with large (380k, 3.8M items) arrays. These cases only run the function once per array:

```
Creating array took: 19.306ms

Sample: array of numbers
Length: 380000
Smooth: 5

for: 17.079ms
map: 318.497ms

--------------------

Sample: array of objects
Length: 380000
Smooth: 5

for: 24.735ms
map: 377.331ms

--------------------

Sample: array of numbers
Length: 380000
Smooth: 20

for: 121.352ms
map: 703.022ms

--------------------

Sample: array of numbers
Length: 3800000
Smooth: 5

for: 401.503ms
map: 3128.323ms
```

_NOTE_: In the case of _big arrays_, I left the 38 million items array case commented out as it took between 1 and 2 minutes (depending on smooth) to run with old map implementation.

Benchmark code is included. To run do:

```
$ node bechmarks/big-array
$ node bechmarks/ops-per-second
```