### PR TITLE
Remove smoothMap requires & benchmark

### DIFF
--- a/benchmarks/big-array.js
+++ b/benchmarks/big-array.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-console,camelcase,no-plusplus,no-use-before-define */
-const smoothMap = require('./map-implementation')
 const smoothFor = require('../lib')
 const sample = require('../test/fixture')
 
@@ -49,14 +48,6 @@ function large_array_benchmark(times, smooth_factor, map, getter) {
     smoothFor(big_array, smooth_factor)
   }
   console.timeEnd('for')
-
-  console.time('map')
-  if (getter) {
-    smoothMap(big_array, smooth_factor, getter)
-  } else {
-    smoothMap(big_array, smooth_factor)
-  }
-  console.timeEnd('map')
 
   console.log()
   console.log('--------------------')

--- a/benchmarks/ops-per-second.js
+++ b/benchmarks/ops-per-second.js
@@ -2,7 +2,6 @@
 /* eslint-disable import/no-extraneous-dependencies */
 const Benchmark = require('benchmark')
 
-const smoothMap = require('./map-implementation')
 const smoothFor = require('../lib')
 const sample = require('../test/fixture')
 


### PR DESCRIPTION
The old map/reduce based implementation was removed in #8 but this stuff was left.